### PR TITLE
35-tsh-front-dashboard-profile-listing-landing-page

### DIFF
--- a/app_front-end/src/App.css
+++ b/app_front-end/src/App.css
@@ -7,7 +7,7 @@
 /* Do not reset form field padding (shadcn / Tailwind) */
 /* *:not(input):not(textarea):not(select):not(button) {
   padding: 0;
-} */ */
+} */
 
 :root {
   --color-primary: #176B87;

--- a/app_front-end/src/components/commons/Header.tsx
+++ b/app_front-end/src/components/commons/Header.tsx
@@ -1,17 +1,29 @@
 import "../../styles/Header.css";
-import { useState } from "react";
-import { useLocation } from "@tanstack/react-router";
+import { useState, type FC } from "react";
+import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useLogoutUser } from "@/hooks/useAuthQuery";
 
-export const Header: React.FC = () => {
+export const Header: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { pathname } = useLocation();
-  const isAuthPage = pathname === "/login";
+  const navigate = useNavigate();
+  const isAuthPage = pathname === "/" || pathname === "/login";
   const { mutate: logoutUser, isPending } = useLogoutUser();
 
   const handleLogout = () => {
     logoutUser();
   };
+
+  const goToDashboard = () => {
+    setMenuOpen(false);
+    navigate({ to: "/dashboard" });
+  };
+
+  const goToProfile = () => {
+    setMenuOpen(false);
+    navigate({ to: "/profile" });
+  };
+
   return (
     <nav className="navbar">
       <ul className="nav-left">
@@ -40,12 +52,12 @@ export const Header: React.FC = () => {
         <ul className="nav-center">
         {!isAuthPage && (
             <li>
-              <button >Tableau de bord</button>
+              <button onClick={goToDashboard}>Tableau de bord</button>
             </li>
           )}
           {!isAuthPage && (
             <li>
-              <button>Mon Profil</button>
+              <button onClick={goToProfile}>Mon Profil</button>
             </li>
           )}
         </ul>

--- a/app_front-end/src/components/dashboard/DashboardProfileCard.tsx
+++ b/app_front-end/src/components/dashboard/DashboardProfileCard.tsx
@@ -1,0 +1,93 @@
+import type { ApiUser, needs, skills } from "../../types/UserProfile.types";
+
+const getProfileImage = (user: ApiUser): string | null =>
+  user.profilePictureUrl ??
+  user.profilePicture ??
+  user.avatarUrl ??
+  user.photo ??
+  null;
+
+const getKnowledgeName = (item: skills | needs): string | null =>
+  item.knowledgeName?.trim() || null;
+
+const KnowledgeBadges = ({
+  items,
+  emptyLabel,
+}: {
+  items: (skills | needs)[];
+  emptyLabel: string;
+}) => {
+  const names = items.map(getKnowledgeName).filter((name): name is string =>
+    Boolean(name),
+  );
+
+  if (names.length === 0) {
+    return <p className="text-sm italic text-muted-foreground">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {names.map((name) => (
+        <span
+          key={name}
+          className="rounded-full border border-primary-border/20 bg-primary-border/10 px-3 py-1 text-xs font-semibold text-primary-border"
+        >
+          {name}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export function DashboardProfileCard({ user }: { user: ApiUser }) {
+  const fullName = `${user.firstName} ${user.lastName}`.trim();
+  const location = [user.city, user.country].filter(Boolean).join(", ");
+  const profileImage = getProfileImage(user);
+
+  return (
+    <article className="flex h-full flex-col rounded-2xl border border-primary-border/10 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex items-center gap-4">
+        {profileImage ? (
+          <img
+            src={profileImage}
+            alt={`Photo de profil de ${fullName}`}
+            className="h-20 w-20 rounded-full border-4 border-primary-border/20 object-cover"
+          />
+        ) : (
+          <div
+            aria-label={`Photo de profil non renseignée pour ${fullName}`}
+            className="h-20 w-20 rounded-full border-4 border-dashed border-primary-border/20 bg-page-bg"
+          />
+        )}
+        <div>
+          <h2 className="text-xl font-bold text-text">{fullName}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {location || "Ville non renseignée"}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-1 flex-col gap-5">
+        <section>
+          <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
+            Compétences
+          </h3>
+          <KnowledgeBadges
+            items={user.skills ?? []}
+            emptyLabel="Aucune compétence renseignée"
+          />
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
+            Besoins
+          </h3>
+          <KnowledgeBadges
+            items={user.needs ?? []}
+            emptyLabel="Aucun besoin renseigné"
+          />
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/app_front-end/src/hooks/useUserQuery.ts
+++ b/app_front-end/src/hooks/useUserQuery.ts
@@ -5,7 +5,12 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { DeleteProfilUser, getUserById, updateProfilUser } from "../services/userService";
+import {
+  DeleteProfilUser,
+  getAllUsers,
+  getUserById,
+  updateProfilUser,
+} from "../services/userService";
 import type { UpdateProfilUserVariables } from "../types/auth.types";
 import { useToast, TOAST_SEVERITY } from "../context/ToastContext";
 
@@ -24,6 +29,14 @@ export function useUserQuery(userId: number) {
     queryKey: ["user", userId],
     queryFn: () => getUserById(userId),
     enabled: userId > 0,
+  });
+}
+
+export function useUsersQuery(enabled = true) {
+  return useQuery({
+    queryKey: ["users"],
+    queryFn: getAllUsers,
+    enabled,
   });
 }
 

--- a/app_front-end/src/pages/DashboardPage.tsx
+++ b/app_front-end/src/pages/DashboardPage.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Header } from "../components/commons/Header";
+import { DashboardProfileCard } from "../components/dashboard/DashboardProfileCard";
+import { useAuth } from "../context/AuthContext";
+import { useUsersQuery } from "../hooks/useUserQuery";
+import "../App.css";
+
+const DashboardState = ({ message }: { message: string }) => (
+  <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-primary-border/10 bg-white p-8 text-center shadow-sm">
+    <p className="text-base font-semibold text-text">{message}</p>
+  </div>
+);
+
+export function DashboardPage() {
+  const { userId, isLoading: authLoading, isError: authError } = useAuth();
+  const navigate = useNavigate();
+  const isAuthenticated = Boolean(userId);
+
+  const {
+    data: users = [],
+    isPending: usersLoading,
+    isError: usersError,
+    error,
+  } = useUsersQuery(isAuthenticated);
+
+  useEffect(() => {
+    if (!authLoading && (authError || !isAuthenticated)) {
+      navigate({ to: "/login" });
+    }
+  }, [authError, authLoading, isAuthenticated, navigate]);
+
+  const renderContent = () => {
+    if (authLoading || usersLoading) {
+      return <DashboardState message="Chargement des profils..." />;
+    }
+
+    if (usersError) {
+      return (
+        <DashboardState
+          message={
+            error instanceof Error
+              ? error.message
+              : "Impossible de récupérer les profils."
+          }
+        />
+      );
+    }
+
+    if (users.length === 0) {
+      return <DashboardState message="Aucun profil disponible pour le moment." />;
+    }
+
+    return (
+      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        {users.map((user) => (
+          <DashboardProfileCard
+            key={user.id ?? `${user.email}-${user.firstName}-${user.lastName}`}
+            user={user}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  if (!authLoading && !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="app">
+      <Header />
+
+      <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:py-12">
+        <header className="max-w-3xl">
+          <p className="mb-2 text-sm font-bold uppercase tracking-[0.16em] text-primary-border">
+            Dashboard
+          </p>
+          <h1 className="text-3xl font-bold text-text">
+            Découvrez les membres de TrocSkillHub
+          </h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            Parcourez les profils, compétences et besoins des utilisateurs pour
+            trouver de nouvelles opportunités d&apos;échange.
+          </p>
+        </header>
+
+        {renderContent()}
+      </main>
+
+      <footer className="app-footer">
+        <div className="app-footer__content">
+          <p className="footer-copyright">
+            ©2026 Troc-SkillHub. Tous droits réservés
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app_front-end/src/routeTree.ts
+++ b/app_front-end/src/routeTree.ts
@@ -1,4 +1,5 @@
 import { rootRoute } from "./routes/__root";
+import { dashboardRoute } from "./routes/dashboard";
 import { indexRoute } from "./routes/index";
 import { loginRoute } from "./routes/login";
 import { profileRoute } from "./routes/profile";
@@ -6,5 +7,6 @@ import { profileRoute } from "./routes/profile";
 export const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
+  dashboardRoute,
   profileRoute,
 ]);

--- a/app_front-end/src/routes/dashboard.tsx
+++ b/app_front-end/src/routes/dashboard.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from "@tanstack/react-router";
+import { DashboardPage } from "../pages/DashboardPage";
+import { rootRoute } from "./__root";
+
+export const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/dashboard",
+  component: DashboardPage,
+});

--- a/app_front-end/src/testing/testRouter.tsx
+++ b/app_front-end/src/testing/testRouter.tsx
@@ -32,6 +32,11 @@ export function createComponentTestRouter(
       path: "/profile",
       component: Component,
     }),
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/dashboard",
+      component: Component,
+    }),
   ]);
 
   return createRouter({

--- a/app_front-end/src/types/UserProfile.types.ts
+++ b/app_front-end/src/types/UserProfile.types.ts
@@ -40,6 +40,10 @@ export interface ApiUser {
   firstName: string;
   lastName: string;
   email: string;
+  photo?: string | null;
+  avatarUrl?: string | null;
+  profilePicture?: string | null;
+  profilePictureUrl?: string | null;
   address?: string | null;
   city: string;
   country: string;


### PR DESCRIPTION
Add authenticated dashboard profile listing.
Implement a protected dashboard route that fetches user profiles from the /users API and displays responsive profile cards with loading, empty, and error states.