### PR TITLE
docs: audit cybersécurité (OWASP) et RGPD du front-end

### DIFF
--- a/AUDIT-RGPD.md
+++ b/AUDIT-RGPD.md
@@ -1,0 +1,105 @@
+# Audit RGPD : TrocSkillHub Front-end
+
+> Branche : `audit-cyber-rgpd`
+> Périmètre : SPA React/Vite (`app_front-end/src`, `index.html`, services d'appel, formulaires, routes). Cookies/traceurs, requêtes tierces depuis le navigateur, stockage local, information des personnes, minimisation des formulaires, droits côté UI.
+> Rôle du projet : l'exploitant de TrocSkillHub est **responsable de traitement** ; l'équipe technique fournit les moyens techniques. Le stockage en base et les durées de conservation relèvent du back (audité dans le repo back-end).
+> Ce document est un audit technique de conformité, **pas un avis juridique**. Les décisions marquées « responsable / DPO » relèvent du responsable de traitement.
+
+## Verdict
+
+**Écarts à corriger avant prod.** Le socle est sain : aucun traceur analytics ni cookie non essentiel (pas de gtag, matomo, fbq, hotjar, sentry), aucun stockage local de PII, aucune injection HTML dangereuse. Deux manques réels d'information/transfert à traiter : le chargement de Google Fonts depuis les serveurs Google (transfert hors UE, IP révélée) et l'absence totale de politique de confidentialité / mentions légales / information au moment de la collecte.
+
+Récapitulatif : **0 bloquant, 2 majeurs, 5 mineurs.**
+
+---
+
+## Findings
+
+### [majeur] Chargement de Google Fonts depuis les serveurs Google : transfert hors UE, IP exposée sans base ni information
+
+- **Fichier** : `app_front-end/index.html:7-12`
+- **Risque** : `preconnect` puis `<link>` vers `https://fonts.googleapis.com` et `https://fonts.gstatic.com` (police Inter). Au chargement de chaque page, avant toute action ou consentement, le navigateur émet une requête vers Google LLC qui capte l'adresse IP (donnée personnelle) et le user-agent. Google est un tiers établi hors UE : transfert international (**art. 44 et suivants**) sans information ni encadrement documenté. C'est le motif qui a valu des condamnations en Europe (jurisprudence LG München 2022 sur Google Fonts distant). Vérifié : c'est le seul domaine externe chargé dans le HTML, aucun autre CDN.
+- **Qui agit** : responsable de traitement (licéité/information), équipe technique (mise en œuvre : héberger la police en local).
+- **Correction attendue** : auto-héberger la police (télécharger les `.woff2`, servir depuis `/public`, supprimer les `preconnect` et le `<link>` Google), ce qui élimine la requête tierce. À défaut, documenter et encadrer le transfert.
+
+### [majeur] Absence de politique de confidentialité, mentions légales, CGU et d'information au moment de la collecte
+
+- **Fichier** : formulaire de collecte `app_front-end/src/components/auth/RegisterForm.tsx:83-236` (aucun lien légal, aucune case de consentement) ; pied de page `app_front-end/src/pages/ProfilPage.tsx:35-44` (liens « À Propos », « Contact », « FAQ » seulement, ancres mortes `#about`/`#contact`/`#faq`) ; grep global `confidentialit|mentions|cgu|privacy|politique|consent|rgpd` = aucune occurrence dans tout `src/`.
+- **Risque** : l'inscription collecte identité (nom, prénom), email et ville sans aucun lien vers une information sur le traitement (finalités, base légale, durée, droits, responsable), ni case d'acceptation des CGU. Manquement à l'obligation d'information au moment de la collecte (**art. 12, 13**). Aucune page légale n'existe ni n'est routée (routes déclarées : `/`, `/login`, `/dashboard`, `/profile`).
+- **Qui agit** : responsable de traitement (rédaction de la politique de confidentialité, mentions légales, CGU, choix de la base légale), équipe technique (création des pages/routes et du lien d'information à côté du bouton « Créer mon compte »).
+- **Correction attendue** : créer les pages Politique de confidentialité, Mentions légales et CGU, les router, les lier dans le pied de page et à proximité du formulaire d'inscription.
+
+### [mineur] Champs libres du profil pouvant capter des données sensibles (art. 9) sans avertissement, profil type CV très riche en PII
+
+- **Fichier** : `app_front-end/src/constantes.ts:75-79` (champ `description` de projet en `textarea`) ; `app_front-end/src/components/ProfilePageComponents/ProfileItemsEditor.tsx:65-86` (rendu du textarea libre) ; formations/expériences/projets/compétences agrégés en profil type CV.
+- **Risque** : un champ de description libre peut recueillir spontanément des données de l'**art. 9** (santé, opinions, appartenance syndicale, orientation) sans que l'utilisateur soit averti, et sans base légale renforcée. Combiné au caractère CV du profil, cela concentre beaucoup de PII. Minimisation (**art. 5-1-c**) et vigilance art. 9.
+- **Qui agit** : responsable de traitement (politique sur les données sensibles), équipe technique (libellé d'avertissement près des champs libres).
+- **Correction attendue** : afficher une mention « ne renseignez pas de données sensibles (santé, opinions, etc.) » près des zones de texte libre ; confirmer que chaque champ collecté est nécessaire à la finalité.
+
+### [mineur] Saisie de la ville envoyée à un tiers (API BAN) à chaque frappe, à documenter
+
+- **Fichier** : `app_front-end/src/constantes.ts:14` ; `app_front-end/src/services/banService.ts:50-81` ; `app_front-end/src/hooks/useBanCommuneSearch.ts`
+- **Risque** : la ville tapée est envoyée en autocomplétion vers `https://api-adresse.data.gouv.fr/search` (service public DINUM, hébergé en France, donc UE). Requête tierce révélant l'IP de l'utilisateur à ce service, déclenchée dès 2 caractères saisis. Pas d'illégalité (finalité légitime, tiers UE, service de l'État), mais à documenter dans l'information des personnes.
+- **Qui agit** : responsable de traitement (mention dans la politique de confidentialité et le registre).
+- **Correction attendue** : mentionner l'appel à l'API BAN (finalité : aide à la saisie de la commune, destinataire : DINUM, UE) dans l'information des personnes. Aucun changement de code requis.
+
+### [mineur] Journalisation console d'erreurs sur les flux d'authentification en production
+
+- **Fichier** : `app_front-end/src/services/authService.ts:24,50,70,89` ; `app_front-end/src/services/passwordResetService.ts:35,46,57`
+- **Risque** : `console.error` sur les erreurs d'inscription, connexion, récupération utilisateur et reset. Vérifié : les chaînes loggées ne contiennent pas de PII en clair, mais l'objet `error` associé peut porter des retours d'API et ces logs restent actifs en production (aucun garde `import.meta.env.DEV`). Bonne pratique de journalisation (**art. 32**).
+- **Qui agit** : équipe technique.
+- **Correction attendue** : retirer ou conditionner ces `console.error` au mode développement, ou s'assurer qu'aucune donnée sensible n'y transite.
+
+### [mineur] Absence de fonction d'export/portabilité des données côté UI
+
+- **Fichier** : composants profil `app_front-end/src/components/ProfilePageComponents/` (grep `export|download|portab|télécharg` = aucune fonctionnalité d'export)
+- **Risque** : l'utilisateur peut accéder à ses données (affichage profil), les rectifier (EditableProfileCard / ProfileItemsEditor) et les effacer (ProfileDeleteModal → `DELETE /users/me`, `userService.ts:79-97`), mais aucun moyen d'obtenir une copie exportable (**art. 20**, portabilité). Elle peut être traitée par demande au responsable, mais son absence en UI est une lacune.
+- **Qui agit** : responsable de traitement (canal d'exercice du droit), équipe technique si export self-service retenu.
+- **Correction attendue** : prévoir un canal de portabilité (bouton d'export ou procédure documentée).
+
+### [mineur] Récupération de la liste complète des utilisateurs avec leurs PII côté client
+
+- **Fichier** : `app_front-end/src/services/userService.ts:26-37` (`getAllUsers` → `GET /users`, normalise skills, needs, education, experience, project pour chaque utilisateur)
+- **Risque** : tout utilisateur connecté récupère l'ensemble des profils avec parcours et compétences. Cohérent avec un annuaire de membres, mais la portée exacte des champs exposés (parcours détaillé, champs libres) relève de la minimisation. Le filtrage réel est côté back.
+- **Qui agit** : responsable de traitement (proportionnalité des données affichées), équipe back.
+- **Correction attendue** : confirmer que `/users` ne renvoie que les champs strictement nécessaires à l'annuaire, pas l'intégralité du CV. À confirmer côté back.
+
+---
+
+## Cartographie des flux de données personnelles côté client
+
+| Donnée | Formulaire / source | Destination | Tiers UE ? |
+|---|---|---|---|
+| Nom, prénom, email, ville, mot de passe | RegisterForm (`/auth/register`) | API back TrocSkillHub (`VITE_API_BASE_URL`) | Selon hébergeur back, à confirmer |
+| Email, mot de passe | LoginForm (`/auth/login`, `credentials: include`) | API back TrocSkillHub | Selon hébergeur back |
+| Email (reset), code, nouveau mot de passe | PasswordResetModal (`/auth/password-reset`) | API back TrocSkillHub | Selon hébergeur back |
+| Ville saisie (autocomplétion, dès 2 caractères) | FranceCityAutocomplete / banService | `api-adresse.data.gouv.fr` (BAN, DINUM) | Oui (France) |
+| Profil CV : formations, expériences, projets (description libre), liens, compétences | EditableProfileCard / ProfileItemsEditor (`PATCH /users/me`) | API back TrocSkillHub | Selon hébergeur back |
+| Identité de l'utilisateur courant | AuthContext (`GET /auth/me`) | API back TrocSkillHub | Selon hébergeur back |
+| Profils de tous les membres (parcours, compétences) | getAllUsers (`GET /users`) | API back → navigateur | Selon hébergeur back |
+| Adresse IP + user-agent | Chargement de page (Google Fonts) | `fonts.googleapis.com` / `fonts.gstatic.com` (Google LLC) | **Non (hors UE)** |
+| Cookie de session d'authentification | httpOnly posé par le back (`credentials: include`) | API back TrocSkillHub | Cookie strictement nécessaire, pas de consentement requis |
+
+Aucun `localStorage`, `sessionStorage` ni `document.cookie` manipulé côté client (grep vide). Aucun traceur analytics/publicitaire.
+
+---
+
+## À porter au registre / à la doc du responsable
+
+- Politique de confidentialité, mentions légales et CGU à rédiger et publier, avec information au moment de la collecte sur le formulaire d'inscription.
+- Base légale de chaque traitement (inscription, profil, annuaire de membres) à définir et documenter.
+- Transfert hors UE via Google Fonts : à supprimer (auto-hébergement) ou à encadrer et déclarer.
+- Recours à l'API BAN (DINUM) pour l'autocomplétion de commune : finalité, destinataire, localisation UE, à mentionner dans l'information et le registre.
+- Modalités d'exercice des droits, notamment portabilité (**art. 20**), absente de l'UI ; accès/rectification/effacement sont présents côté UI.
+- Vérifier côté back la minimisation des champs renvoyés par `GET /users` à l'ensemble des membres.
+- Prévoir une mention de non-saisie de données sensibles sur les champs libres du profil.
+
+---
+
+## Top 3 à traiter en priorité
+
+1. **Google Fonts chargé depuis les serveurs Google** — transfert hors UE et IP exposée sans base ni information (art. 44+).
+2. **Absence totale de politique de confidentialité, mentions légales, CGU et d'information au moment de la collecte** (art. 12-13).
+3. **Champs libres du profil pouvant capter des données sensibles (art. 9)** sans avertissement.
+
+Donnée la plus à risque : le profil de type CV (formations, expériences, descriptions de projet en texte libre), concentré de PII susceptible de contenir des données de l'art. 9, exposé de surcroît aux autres membres via `GET /users`.

--- a/AUDIT-SECURITE.md
+++ b/AUDIT-SECURITE.md
@@ -1,0 +1,86 @@
+# Audit sécurité (OWASP) : TrocSkillHub Front-end
+
+> Branche : `audit-cyber-rgpd`
+> Périmètre : SPA React/Vite (`app_front-end/src`, services d'appel API, config build, nginx, Dockerfile).
+> Méthode : audit statique selon OWASP Top 10 web, adapté au contexte client. Aucune modification de code.
+> **Rappel de portée** : un front SPA n'est jamais une frontière de sécurité (l'autorisation réelle est côté API, auditée dans le repo back-end). Les contrôles d'accès manquants côté client ne sont donc pas classés bloquants ici ; on cible ce qui est exploitable côté navigateur (XSS, secret exposé dans le bundle, token volable, posture serveur).
+
+## Verdict
+
+**Écarts à corriger avant prod.** Aucun bloquant exploitable aujourd'hui. Une XSS latente (neutralisée par le mapper actuel mais prête à s'activer) et une posture serveur à durcir.
+
+Récapitulatif : **0 bloquant, 0 majeur, 4 mineurs.**
+
+---
+
+## Findings
+
+### [mineur] href construit depuis une donnée profil non validée : XSS latente par URI `javascript:` (OWASP A03 — Injection)
+
+- **Fichier** : `app_front-end/src/components/ProfilePageComponents/UserCard.tsx:33,46`
+- **Faille** : `href={linkedin}` et `href={instagram}` injectent directement une chaîne provenant du profil utilisateur (type `string` libre, `types/UserProfile.types.ts:80-81`). React n'assainit PAS l'attribut `href` : une valeur `javascript:...` reste cliquable et s'exécute. Le `rel="noopener noreferrer"` est présent (le risque `target="_blank"` est couvert) ; le problème est l'origine non contrôlée de l'URL.
+- **Scénario d'exploitation** : un utilisateur enregistre `javascript:fetch('/users/me',{method:'DELETE',credentials:'include'})` comme lien LinkedIn. Une victime consultant son profil et cliquant sur « LinkedIn » exécute ce script dans SA session authentifiée (stored XSS déclenchée au clic). Le cookie httpOnly n'est pas lisible, mais l'attaquant pilote l'API avec les droits de la victime.
+- **Non exploitable en l'état** : `utils/userMapper.ts:13-14` force `linkedin: undefined` / `instagram: undefined`, donc l'ancre n'est jamais rendue. C'est une régression prête à s'activer dès qu'on branchera ces champs sur l'API.
+- **Correction attendue** : valider le schéma d'URL avant rendu (n'autoriser que `https:`/`http:`, rejeter `javascript:`, `data:`, `vbscript:`), via un helper partagé `safeUrl()`. Le champ « Lien » de projet (`ProfileMain.tsx:707`) est lui rendu en texte échappé (`Lien : {item.links}`) donc sûr.
+
+### [mineur] Absence d'en-têtes de sécurité HTTP (dont CSP) (OWASP A05 — Security Misconfiguration)
+
+- **Fichier** : `app_front-end/nginx.conf` (bloc `server`), `app_front-end/api-proxy.conf.template`
+- **Faille** : le serveur nginx qui sert le build ne pose aucun `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options`/`frame-ancestors`, ni `Referrer-Policy`. Aucune CSP ne viendrait donc contenir une XSS (voir finding précédent) ni bloquer le clickjacking.
+- **Scénario d'exploitation** : en cas d'injection réussie, aucune CSP ne limite l'exfiltration vers un domaine tiers. Sans `X-Frame-Options`, la SPA peut être encadrée dans un iframe pour du clickjacking sur les actions sensibles (suppression de compte).
+- **Correction attendue** : ajouter les `add_header` de sécurité dans le bloc `server` nginx (CSP restrictive autorisant `self`, `api-adresse.data.gouv.fr` pour la BAN, et la police retenue ; `nosniff` ; `frame-ancestors 'none'` ; `Referrer-Policy: strict-origin-when-cross-origin`).
+
+### [mineur] `.DS_Store` versionné à la racine du dépôt (OWASP A05 — Security Misconfiguration)
+
+- **Fichier** : `TrocSkillHub_Front-end/.DS_Store` (présent dans `git ls-files`)
+- **Faille** : fichier macOS committé, alors que le `.gitignore` racine l'exclut pourtant. Il révèle la structure de dossiers locale.
+- **Scénario d'exploitation** : fuite mineure d'arborescence/nommage interne pour un attaquant en reconnaissance.
+- **Correction attendue** : `git rm --cached .DS_Store` puis commit. Le `.dockerignore` l'exclut déjà du build image, donc pas de fuite via l'image nginx.
+
+### [mineur] `jsdom` déclaré en dependency de production (OWASP A06 — Vulnerable/Outdated Components)
+
+- **Fichier** : `app_front-end/package.json:23` (dans `dependencies`, et re-déclaré en `devDependencies:46`)
+- **Faille** : `jsdom` est un outil de test/SSR sans usage runtime dans un front SPA. En `dependencies` il alourdit l'arbre installé en prod et élargit la surface d'appro (transitives lourdes). Aucun `import` de jsdom dans `src/` (le bundle Vite ne l'embarque donc pas), mais sa présence en dépendance de prod reste anormale.
+- **Scénario d'exploitation** : pas d'exploitation côté client direct ; risque supply-chain / faux positifs d'audit.
+- **Correction attendue** : retirer `jsdom` de `dependencies` (le garder uniquement en `devDependencies`).
+
+---
+
+## Surface analysée (services, appels réseau, points d'entrée)
+
+- Services API back (même origine via proxy `/api` ou `VITE_API_BASE_URL`), tous en `credentials: 'include'` : `authService.ts`, `userService.ts` (getAllUsers, `/me`, PATCH, DELETE), `passwordResetService.ts`, `knowledgeService.ts`. Aucune URL construite depuis une entrée utilisateur, aucun open redirect.
+- Tiers navigateur : API BAN `https://api-adresse.data.gouv.fr/search` via `banService.ts` + `useBanCommuneSearch.ts`. URL construite proprement via `URL`/`searchParams` (pas d'injection d'hôte). Saisie de commune envoyée à ce service public (donnée peu sensible), à mentionner côté RGPD.
+- Auth : `AuthContext.tsx` lit `/auth/me` via React Query, aucun token manipulé en JS.
+- Config : `constantes.ts` (une seule var `VITE_API_BASE_URL`, non secrète), `vite.config.ts` (pas de sourcemap prod, pas de proxy exposé), `Dockerfile` (build multi-stage, nginx-unprivileged non-root, `VITE_API_BASE_URL` en build-arg non secret), `nginx.conf`, `.gitignore`/`.dockerignore`.
+
+---
+
+## Points sûrs notables (à ne pas régresser)
+
+- Aucun `dangerouslySetInnerHTML`, `innerHTML`, `eval`, `new Function`, insertion de `<script>` dans `src/`. React échappe le rendu par défaut, tout le contenu API/utilisateur est rendu en texte.
+- **Aucun `localStorage` / `sessionStorage` / `document.cookie`** : le JWT reste en cookie httpOnly côté back (`credentials: 'include'`), donc non volable par XSS. Bonne pratique respectée.
+- Aucune variable `VITE_*` secrète, aucun secret/clé/mot de passe en dur dans `src/`, `vite.config.ts`, `Dockerfile`, `nginx.conf`. Aucun `.env` versionné.
+- Devtools TanStack Router gardés par `import.meta.env.DEV` (`routes/__root.tsx:9`) : jamais servis en prod. React Query Devtools non montés.
+- Les seuls `console.error` (services) loguent des libellés génériques et l'objet erreur, pas de PII ni de token explicite.
+- `target="_blank"` accompagnés de `rel="noopener noreferrer"` (`UserCard.tsx`).
+- Dockerfile : image finale `nginxinc/nginx-unprivileged`, `USER nginx`, ne copie que `dist/` (pas les sources ni `.env`), `.dockerignore` exclut `node_modules`, `.env.local`, `.git`, `.DS_Store`.
+
+---
+
+## Non vérifiable statiquement (relève de l'audit back ou du runtime)
+
+- Contenu réel des réponses `/auth/me`, `/users` : présence éventuelle de champs sensibles renvoyés au client au-delà du nécessaire (minimisation) relève de l'audit back.
+- Attributs réels du cookie de session (`HttpOnly`, `Secure`, `SameSite`) : posés côté Spring Boot.
+- Configuration CORS et valeur de production de `VITE_API_BASE_URL` (origine visée par `credentials: 'include'`) : à confirmer au déploiement.
+- Efficacité anti-bruteforce / rate-limiting du reset et du login : côté back.
+- Versions de dépendances : numéros du manifeste non confrontés à une base CVE (`npm audit` non lancé).
+
+---
+
+## Top 3 à traiter en priorité
+
+1. **href profil non validé** (A03) — XSS latente par `javascript:` URI, neutralisée aujourd'hui par le mapper mais à assainir avant de brancher `linkedin`/`instagram` sur l'API.
+2. **Absence de CSP et d'en-têtes de sécurité nginx** (A05).
+3. **`.DS_Store` versionné** (A05).
+
+Point le plus exposé : le rendu `href={linkedin/instagram}` de `UserCard.tsx`, seule véritable primitive XSS du front.


### PR DESCRIPTION
## Objet

Ajout de deux comptes rendus d'**audit statique** du front-end, sans aucune modification du code applicatif. Le diff se limite à deux fichiers Markdown à la racine.

- `AUDIT-SECURITE.md` — audit sécurité selon l'**OWASP Top 10 web**, adapté au contexte client (SPA).
- `AUDIT-RGPD.md` — audit de conformité **RGPD** côté navigateur.

Chaque finding est vérifié dans le code (`fichier:ligne`), classé par gravité et assorti d'un scénario / d'un article RGPD et d'une correction attendue. Aucune correction n'est appliquée : ce sont des recommandations.

> **Portée** : un front SPA n'est jamais une frontière de sécurité (l'autorisation réelle est côté API, auditée dans le repo back-end). L'audit sécurité cible donc ce qui est exploitable côté navigateur (XSS, secrets dans le bundle, token volable, posture serveur), pas les contrôles d'accès.

## Synthèse sécurité (OWASP)

**Verdict : écarts à corriger avant prod, aucun bloquant.** 0 bloquant, 0 majeur, 4 mineurs.

Le socle est sain : pas de token en `localStorage` (JWT en cookie httpOnly), pas de secret dans le bundle, aucun `dangerouslySetInnerHTML`/`eval`, devtools gardés en DEV, Dockerfile non-root ne copiant que `dist/`.

Top 3 :
1. **[mineur]** `href={linkedin/instagram}` non validé dans `UserCard.tsx` (A03) — XSS latente par URI `javascript:`, aujourd'hui neutralisée par le mapper qui force `undefined`, mais à assainir avant de brancher ces champs sur l'API.
2. **[mineur]** Absence de CSP et d'en-têtes de sécurité nginx (A05).
3. **[mineur]** `.DS_Store` versionné + `jsdom` en dependency de prod (A05/A06).

## Synthèse RGPD

**Verdict : écarts à corriger avant prod.** 0 bloquant, 2 majeurs, 5 mineurs.

Aucun traceur analytics ni cookie non essentiel, aucun stockage local de PII : le socle est propre.

Top 3 :
1. **[majeur]** Google Fonts chargé depuis `fonts.googleapis.com`/`gstatic.com` (`index.html:7-12`) — transfert hors UE et IP exposée sans base ni information (art. 44+). Correction : auto-héberger la police.
2. **[majeur]** Absence totale de politique de confidentialité, mentions légales, CGU et d'information au moment de la collecte (art. 12-13) — l'inscription collecte identité + email + ville sans aucun lien d'information ni case CGU.
3. **[mineur]** Champs libres du profil (descriptions type CV) pouvant capter des données sensibles art. 9 sans avertissement.

À noter côté positif : accès, rectification et effacement (`DELETE /users/me`) sont présents dans l'UI ; l'API BAN (autocomplétion de ville) est un tiers UE (DINUM), à documenter.

## Portée / réserve

Audit **statique** uniquement. Le contenu réel des réponses API (`/users`, `/me`), les attributs du cookie de session, la config CORS et les versions de dépendances (pas de `npm audit`) relèvent de l'audit back-end ou du runtime. Les décisions juridiques (pages légales, base légale, transferts) relèvent du responsable de traitement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
