### PR TITLE
73 tsh front feat add explanatory text on the authentication page

### DIFF
--- a/app_front-end/src/components/AuthenticationForm.tsx
+++ b/app_front-end/src/components/AuthenticationForm.tsx
@@ -4,18 +4,34 @@ import { RegisterForm } from "./auth/RegisterForm";
 
 export const AuthentificationForm: React.FC = () => {
   return (
-    <div className="grid min-h-screen grid-cols-[1fr_auto_1fr] items-center bg-page-bg p-8 box-border max-lg:grid-cols-1 max-lg:grid-rows-[auto_auto_auto] max-lg:px-6 max-lg:py-8 max-md:px-4 max-md:py-5">
-      <RegisterForm />
+    <div className="flex w-full flex-1 flex-col bg-page-bg">
+      <header className="flex w-full justify-center px-5 pt-8 sm:px-8">
+        <div className="w-full max-w-3xl text-center">
+          <h1 className="mb-3 font-heading text-3xl font-bold tracking-tight text-text sm:text-4xl">
+            Bienvenue sur{" "}
+            <span className="text-[#70744f]">TROCSKILLHUB</span>
+          </h1>
+          <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Rejoignez une communauté où chacun partage ses compétences et ses
+            besoins. Inscrivez-vous pour explorer les profils et proposer ou
+            recevoir des échanges de compétences.
+          </p>
+        </div>
+      </header>
 
-      <div className="flex h-[300px] flex-col items-center justify-center gap-3 px-6 max-lg:mx-auto max-lg:h-auto max-lg:w-full max-lg:max-w-[420px] max-lg:flex-row max-lg:px-0 max-lg:py-2">
-        <div className="w-px flex-1 bg-[#b4cfe0] max-lg:h-px max-lg:w-auto" />
-        <span className="font-body text-sm font-bold uppercase tracking-[0.1em] text-text">
-          ou
-        </span>
-        <div className="w-px flex-1 bg-[#b4cfe0] max-lg:h-px max-lg:w-auto" />
+      <div className="grid w-full flex-1 grid-cols-[1fr_auto_1fr] items-center p-8 box-border max-lg:grid-cols-1 max-lg:grid-rows-[auto_auto_auto] max-lg:px-6 max-lg:py-8 max-md:px-4 max-md:py-5">
+        <RegisterForm />
+
+        <div className="flex h-[300px] flex-col items-center justify-center gap-3 px-6 max-lg:mx-auto max-lg:h-auto max-lg:w-full max-lg:max-w-[420px] max-lg:flex-row max-lg:px-0 max-lg:py-2">
+          <div className="w-px flex-1 bg-[#b4cfe0] max-lg:h-px max-lg:w-auto" />
+          <span className="font-body text-sm font-bold uppercase tracking-[0.1em] text-text">
+            ou
+          </span>
+          <div className="w-px flex-1 bg-[#b4cfe0] max-lg:h-px max-lg:w-auto" />
+        </div>
+
+        <LoginForm />
       </div>
-
-      <LoginForm />
     </div>
   );
 };

--- a/app_front-end/src/components/commons/Footer.tsx
+++ b/app_front-end/src/components/commons/Footer.tsx
@@ -18,7 +18,7 @@ export const Footer: React.FC = () => {
             </button>
           </div>
           <p className="footer-copyright">
-            ©2026 Troc-SkillHub. Tous droits réservés
+            ©2026 Trocskillhub. Tous droits réservés
           </p>
         </div>
       </footer>

--- a/app_front-end/src/components/commons/Header.tsx
+++ b/app_front-end/src/components/commons/Header.tsx
@@ -34,7 +34,7 @@ export const Header: FC = () => {
         className="h-20 w-20 object-contain max-sm:h-8 max-sm:w-8"
       />
       <h1 className="font-heading text-xl font-bold text-[#70744f] max-md:text-base max-sm:text-sm">
-        TROCSKILL-HUB
+        TROCSKILLHUB
       </h1>
     </li>
   </ul>

--- a/app_front-end/src/testing/Header.test.tsx
+++ b/app_front-end/src/testing/Header.test.tsx
@@ -24,7 +24,7 @@ const renderHeader = (initialPath = "/") => {
 describe("Header", () => {
   it("shows the title", async () => {
     renderHeader();
-    await expect.element(page.getByText("TROCSKILL-HUB")).toBeInTheDocument();
+    await expect.element(page.getByText("TROCSKILLHUB")).toBeInTheDocument();
   });
 
   it("shows the application logo", async () => {


### PR DESCRIPTION
Add a centered welcome heading and short value proposition above the
login/register forms so visitors understand TrocSkillHub before signing up.
Also align the Header/Footer brand spelling to Trocskillhub.