### PR TITLE
feat: add profile PDF export and align password reset OTP to 6 digits

### DIFF
--- a/app_front-end/src/components/ProfilePageComponents/ProfileMain.tsx
+++ b/app_front-end/src/components/ProfilePageComponents/ProfileMain.tsx
@@ -7,7 +7,11 @@ import { Button } from "primereact/button";
 import { InputText } from "primereact/inputtext";
 import { InputTextarea } from "primereact/inputtextarea";
 import { useKnowledgesQuery } from "../../hooks/useKnowledgesQuery";
-import { useUpdateProfilUser, useUserQuery } from "../../hooks/useUserQuery";
+import {
+  useExportProfileDocument,
+  useUpdateProfilUser,
+  useUserQuery,
+} from "../../hooks/useUserQuery";
 import { mapApiUserToUserCard, getUserDescription } from "../../utils/userMapper";
 import 'primeicons/primeicons.css';
 import {
@@ -114,6 +118,10 @@ const ProfileMain: React.FC = () => {
 
   const { data: user, isLoading, isError, error, refetch } = useUserQuery();
   const { mutate: updateProfil, isPending: isSaving } = useUpdateProfilUser();
+  const {
+    mutate: exportProfile,
+    isPending: isExporting,
+  } = useExportProfileDocument();
   const {
     data: knowledges = [],
     isLoading: knowledgesLoading,
@@ -263,11 +271,23 @@ const ProfileMain: React.FC = () => {
       <div className="flex justify-end gap-x-2">
         <Button
           type="button"
+          icon="pi pi-file-export"
+          label="Exporter mon profil"
+          className="ts-btn-profile ts-btn-secondary"
+          tooltip="Recevoir mon profil en PDF par email"
+          tooltipOptions={TOOLTIP_OPTIONS}
+          loading={isExporting}
+          disabled={isExporting}
+          onClick={() => exportProfile()}
+        />
+
+        <Button
+          type="button"
           icon="pi pi-user-edit"
           severity={isEditing ? "secondary" : undefined}
           outlined={isEditing}
           className="ts-btn-profile ts-btn-secondary"
-          tooltip={isEditing ? "Terminer" : "Modifier"}
+          tooltip={isEditing ? "Terminer" : "modifier"}
           tooltipOptions={TOOLTIP_OPTIONS}
           onClick={() => {
             if (isEditing) {

--- a/app_front-end/src/components/auth/PasswordResetModal.tsx
+++ b/app_front-end/src/components/auth/PasswordResetModal.tsx
@@ -20,7 +20,7 @@ import type {
 } from "../../types/auth.types";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const CODE_PATTERN = /^\d{4}$/;
+const CODE_PATTERN = /^\d{6}$/;
 const RESEND_COOLDOWN_SECONDS = 30;
 
 const STEP_HEADERS: Record<PasswordResetStep, string> = {
@@ -170,7 +170,7 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           style={{ padding: "clamp(15px, 2.5vw, 32px)" }}
         >
           <p className="m-0 text-sm text-text">
-            Saisissez votre adresse email : si un compte existe, un code de vérification à 4
+            Saisissez votre adresse email : si un compte existe, un code de vérification à 6
             chiffres vous sera envoyé.
           </p>
 
@@ -210,7 +210,7 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           style={{ padding: "clamp(15px, 2.5vw, 32px)" }}
         >
           <p className="m-0 text-sm text-text">
-            {"Saisissez le code à 4 chiffres reçu par email à l'adresse "}
+            {"Saisissez le code à 6 chiffres reçu par email à l'adresse "}
             <strong>{email}</strong>.
           </p>
 
@@ -220,14 +220,14 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
               control={codeForm.control}
               rules={{
                 required: "Le code est requis",
-                pattern: { value: CODE_PATTERN, message: "Le code doit contenir exactement 4 chiffres" },
+                pattern: { value: CODE_PATTERN, message: "Le code doit contenir exactement 6 chiffres" },
               }}
               render={({ field }) => (
                 <InputOtp
                   value={field.value ?? ""}
                   onChange={(e) => field.onChange(String(e.value ?? ""))}
                   onBlur={field.onBlur}
-                  length={4}
+                  length={6}
                   integerOnly
                   invalid={!!codeForm.formState.errors.code}
                 />

--- a/app_front-end/src/hooks/useUserQuery.ts
+++ b/app_front-end/src/hooks/useUserQuery.ts
@@ -7,6 +7,7 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import {
   DeleteProfilUser,
+  exportProfileDocument,
   getAllUsers,
   getUserById,
   updateProfilUser,
@@ -77,6 +78,36 @@ export function useDeleteProfilUser() {
         summary: "Erreur",
         detail: error.message ?? "Une erreur est survenue.",
         life: 4000,
+        className: TOAST_SEVERITY.error,
+        contentClassName: "flex items-center gap-3 px-3.5 py-3",
+      });
+    },
+  });
+}
+
+export function useExportProfileDocument() {
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: () => exportProfileDocument(),
+    onSuccess: (message) => {
+      showToast({
+        severity: "success",
+        summary: "Export réussi",
+        detail: message,
+        life: 4000,
+        className: TOAST_SEVERITY.success,
+        contentClassName: "flex items-center gap-3 px-3.5 py-3",
+      });
+    },
+    onError: (error: Error) => {
+      showToast({
+        severity: "error",
+        summary: "Erreur d'export",
+        detail:
+          error.message ??
+          "Impossible d'exporter votre profil. Veuillez réessayer.",
+        life: 5000,
         className: TOAST_SEVERITY.error,
         contentClassName: "flex items-center gap-3 px-3.5 py-3",
       });

--- a/app_front-end/src/services/authService.ts
+++ b/app_front-end/src/services/authService.ts
@@ -10,6 +10,7 @@ export const register = async (
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
 

--- a/app_front-end/src/services/userService.ts
+++ b/app_front-end/src/services/userService.ts
@@ -95,3 +95,47 @@ export const DeleteProfilUser = async (): Promise<void> => {
     throw new Error(message);
   }
 };
+
+const readErrorMessage = async (response: Response): Promise<string> => {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const errorBody = (await response.json().catch(() => null)) as
+      | { error?: string; message?: string }
+      | null;
+    return (
+      errorBody?.error ??
+      errorBody?.message ??
+      `Erreur HTTP: ${response.status}`
+    );
+  }
+  const text = await response.text().catch(() => "");
+  const cleaned = text.replace(/^Erreur:\s*/i, "").trim();
+  return cleaned || `Erreur HTTP: ${response.status}`;
+};
+
+export type ProfileDocumentResponse = {
+  status: "SENT" | "FAILED" | string;
+  recipient?: string | null;
+  documentName?: string | null;
+  message: string;
+};
+
+export const exportProfileDocument = async (): Promise<string> => {
+  const response = await fetch(`${API_USERS_URL}/me/profile-document`, {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response));
+  }
+
+  const data = (await response.json().catch(() => null)) as
+    | ProfileDocumentResponse
+    | null;
+
+  return (
+    data?.message?.trim() ||
+    "Le CV PDF a été envoyé par email"
+  );
+};


### PR DESCRIPTION
Wire the profile page to POST /users/me/profile-document with toast feedback, and update the reset flow for the backend's 6-digit codes.