### PR TITLE
feat: align dashboard with public user DTO and fix auth accessibility

### DIFF
--- a/app_front-end/src/components/auth/FranceCityAutocomplete.tsx
+++ b/app_front-end/src/components/auth/FranceCityAutocomplete.tsx
@@ -10,6 +10,8 @@ export const FranceCityAutocomplete: React.FC<FranceCityAutocompleteProps> = ({
   onChange,
   onBlur,
   disabled = false,
+  id,
+  "aria-labelledby": ariaLabelledBy,
 }) => {
   const listId = useId();
   const [inputValue, setInputValue] = useState(value);
@@ -35,13 +37,16 @@ export const FranceCityAutocomplete: React.FC<FranceCityAutocompleteProps> = ({
   return (
     <div className="relative flex flex-col gap-1">
       <InputText
+        id={id}
         value={inputValue}
         disabled={disabled}
         placeholder="Commune (ex. Paris, 75001…)"
-        autoComplete="off"
+        autoComplete="address-level2"
         role="combobox"
+        aria-labelledby={ariaLabelledBy}
         aria-expanded={isOpen}
         aria-controls={listId}
+        aria-autocomplete="list"
         onFocus={() => setIsOpen(true)}
         onBlur={() => {
           onBlur?.();

--- a/app_front-end/src/components/auth/LoginForm.tsx
+++ b/app_front-end/src/components/auth/LoginForm.tsx
@@ -63,12 +63,21 @@ export const LoginForm: React.FC = () => {
           style={{ padding: "clamp(15px, 2.5vw, 32px)" }}
         >
           <div className="flex flex-col gap-1">
+            <label htmlFor="login-email" className="auth-field-label">
+              Adresse email
+            </label>
             <Controller
               name="email"
               control={control}
               rules={{ required: "L'adresse email est requise" }}
               render={({ field }) => (
-                <InputText {...field} placeholder="Votre email" type="email" />
+                <InputText
+                  {...field}
+                  id="login-email"
+                  placeholder="Votre email"
+                  type="email"
+                  autoComplete="email"
+                />
               )}
             />
             {errors.email && (
@@ -77,12 +86,16 @@ export const LoginForm: React.FC = () => {
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="login-password" className="auth-field-label">
+              Mot de passe
+            </label>
             <Controller
               name="password"
               control={control}
               rules={{ required: "Le mot de passe est requis" }}
               render={({ field }) => (
                 <Password
+                  inputId="login-password"
                   value={field.value}
                   onChange={(e) => field.onChange(e.target.value)}
                   onBlur={field.onBlur}
@@ -90,6 +103,15 @@ export const LoginForm: React.FC = () => {
                   toggleMask
                   feedback={false}
                   className="w-full"
+                  autoComplete="current-password"
+                  pt={{
+                    showIcon: {
+                      "aria-label": "Afficher le mot de passe",
+                    },
+                    hideIcon: {
+                      "aria-label": "Masquer le mot de passe",
+                    },
+                  }}
                 />
               )}
             />

--- a/app_front-end/src/components/auth/PasswordResetModal.tsx
+++ b/app_front-end/src/components/auth/PasswordResetModal.tsx
@@ -175,6 +175,9 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           </p>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="reset-email" className="auth-field-label">
+              Adresse email
+            </label>
             <Controller
               name="email"
               control={emailForm.control}
@@ -183,7 +186,13 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
                 pattern: { value: EMAIL_PATTERN, message: "Email invalide" },
               }}
               render={({ field }) => (
-                <InputText {...field} placeholder="Votre email" type="email" />
+                <InputText
+                  {...field}
+                  id="reset-email"
+                  placeholder="Votre email"
+                  type="email"
+                  autoComplete="email"
+                />
               )}
             />
             {emailForm.formState.errors.email && (
@@ -215,6 +224,9 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           </p>
 
           <div className="flex flex-col items-center gap-1">
+            <label htmlFor="reset-code" id="reset-code-label" className="auth-field-label self-start">
+              Code de vérification
+            </label>
             <Controller
               name="code"
               control={codeForm.control}
@@ -224,12 +236,14 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
               }}
               render={({ field }) => (
                 <InputOtp
+                  id="reset-code"
                   value={field.value ?? ""}
                   onChange={(e) => field.onChange(String(e.value ?? ""))}
                   onBlur={field.onBlur}
                   length={6}
                   integerOnly
                   invalid={!!codeForm.formState.errors.code}
+                  aria-labelledby="reset-code-label"
                 />
               )}
             />
@@ -276,6 +290,9 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           </p>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="reset-new-password" className="auth-field-label">
+              Nouveau mot de passe
+            </label>
             <Controller
               name="newPassword"
               control={newPasswordForm.control}
@@ -285,6 +302,7 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
               }}
               render={({ field }) => (
                 <Password
+                  inputId="reset-new-password"
                   value={field.value ?? ""}
                   onChange={(e) => field.onChange(e.target.value)}
                   onBlur={field.onBlur}
@@ -292,6 +310,11 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
                   toggleMask
                   feedback={false}
                   className="w-full"
+                  autoComplete="new-password"
+                  pt={{
+                    showIcon: { "aria-label": "Afficher le mot de passe" },
+                    hideIcon: { "aria-label": "Masquer le mot de passe" },
+                  }}
                 />
               )}
             />
@@ -303,6 +326,9 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="reset-confirm-password" className="auth-field-label">
+              Confirmer le mot de passe
+            </label>
             <Controller
               name="confirmPassword"
               control={newPasswordForm.control}
@@ -312,6 +338,7 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
               }}
               render={({ field }) => (
                 <Password
+                  inputId="reset-confirm-password"
                   value={field.value ?? ""}
                   onChange={(e) => field.onChange(e.target.value)}
                   onBlur={field.onBlur}
@@ -319,6 +346,11 @@ export const PasswordResetModal: React.FC<PasswordResetModalProps> = ({
                   toggleMask
                   feedback={false}
                   className="w-full"
+                  autoComplete="new-password"
+                  pt={{
+                    showIcon: { "aria-label": "Afficher le mot de passe" },
+                    hideIcon: { "aria-label": "Masquer le mot de passe" },
+                  }}
                 />
               )}
             />

--- a/app_front-end/src/components/auth/RegisterForm.tsx
+++ b/app_front-end/src/components/auth/RegisterForm.tsx
@@ -11,6 +11,15 @@ import type { RegisterFields } from "../../types/auth.types";
 import { AuthMessage } from "./AuthMessage";
 import { FranceCityAutocomplete } from "./FranceCityAutocomplete";
 
+const passwordTogglePt = {
+  showIcon: {
+    "aria-label": "Afficher le mot de passe",
+  },
+  hideIcon: {
+    "aria-label": "Masquer le mot de passe",
+  },
+};
+
 export const RegisterForm: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -87,12 +96,20 @@ export const RegisterForm: React.FC = () => {
         >
           <div className="flex gap-3 max-md:flex-col">
             <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="register-nom" className="auth-field-label">
+                Nom
+              </label>
               <Controller
                 name="nom"
                 control={control}
                 rules={{ required: "Le nom est requis" }}
                 render={({ field }) => (
-                  <InputText {...field} placeholder="Votre nom" />
+                  <InputText
+                    {...field}
+                    id="register-nom"
+                    placeholder="Votre nom"
+                    autoComplete="family-name"
+                  />
                 )}
               />
               {errors.nom && (
@@ -100,12 +117,20 @@ export const RegisterForm: React.FC = () => {
               )}
             </div>
             <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="register-prenom" className="auth-field-label">
+                Prénom
+              </label>
               <Controller
                 name="prenom"
                 control={control}
                 rules={{ required: "Le prénom est requis" }}
                 render={({ field }) => (
-                  <InputText {...field} placeholder="Votre prénom" />
+                  <InputText
+                    {...field}
+                    id="register-prenom"
+                    placeholder="Votre prénom"
+                    autoComplete="given-name"
+                  />
                 )}
               />
               {errors.prenom && (
@@ -115,6 +140,9 @@ export const RegisterForm: React.FC = () => {
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="register-email" className="auth-field-label">
+              Adresse email
+            </label>
             <Controller
               name="email"
               control={control}
@@ -128,8 +156,10 @@ export const RegisterForm: React.FC = () => {
               render={({ field }) => (
                 <InputText
                   {...field}
+                  id="register-email"
                   placeholder="Votre adresse email"
                   type="email"
+                  autoComplete="email"
                 />
               )}
             />
@@ -139,12 +169,17 @@ export const RegisterForm: React.FC = () => {
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="register-city" id="register-city-label" className="auth-field-label">
+              Ville
+            </label>
             <Controller
               name="city"
               control={control}
               rules={{ required: "La ville est requise" }}
               render={({ field }) => (
                 <FranceCityAutocomplete
+                  id="register-city"
+                  aria-labelledby="register-city-label"
                   value={field.value}
                   onChange={field.onChange}
                   onBlur={field.onBlur}
@@ -157,6 +192,9 @@ export const RegisterForm: React.FC = () => {
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="register-password" className="auth-field-label">
+              Mot de passe
+            </label>
             <Controller
               name="password"
               control={control}
@@ -183,6 +221,7 @@ export const RegisterForm: React.FC = () => {
               }}
               render={({ field }) => (
                 <Password
+                  inputId="register-password"
                   value={field.value}
                   onChange={(e) => field.onChange(e.target.value)}
                   onBlur={field.onBlur}
@@ -190,6 +229,8 @@ export const RegisterForm: React.FC = () => {
                   toggleMask
                   feedback={false}
                   className="w-full"
+                  autoComplete="new-password"
+                  pt={passwordTogglePt}
                 />
               )}
             />
@@ -199,6 +240,9 @@ export const RegisterForm: React.FC = () => {
           </div>
 
           <div className="flex flex-col gap-1">
+            <label htmlFor="register-confirm-password" className="auth-field-label">
+              Confirmer le mot de passe
+            </label>
             <Controller
               name="confirmPassword"
               control={control}
@@ -209,6 +253,7 @@ export const RegisterForm: React.FC = () => {
               }}
               render={({ field }) => (
                 <Password
+                  inputId="register-confirm-password"
                   value={field.value}
                   onChange={(e) => field.onChange(e.target.value)}
                   onBlur={field.onBlur}
@@ -216,6 +261,8 @@ export const RegisterForm: React.FC = () => {
                   toggleMask
                   feedback={false}
                   className="w-full"
+                  autoComplete="new-password"
+                  pt={passwordTogglePt}
                 />
               )}
             />

--- a/app_front-end/src/components/commons/Footer.tsx
+++ b/app_front-end/src/components/commons/Footer.tsx
@@ -17,7 +17,7 @@ export const Footer: React.FC = () => {
               Mentions légales
             </button>
           </div>
-          <p className="m-0 text-[13px] text-white/70 max-md:text-xs">
+          <p className="m-0 text-[13px] text-white max-md:text-xs">
             ©2026 Trocskillhub. Tous droits réservés
           </p>
         </div>

--- a/app_front-end/src/components/dashboard/DashboardProfileCard.tsx
+++ b/app_front-end/src/components/dashboard/DashboardProfileCard.tsx
@@ -1,11 +1,9 @@
-import type { ApiUser, needs, skills } from "../../types/UserProfile.types";
-
-const getProfileImage = (user: ApiUser): string | null =>
-  user.profilePictureUrl ??
-  user.profilePicture ??
-  user.avatarUrl ??
-  user.photo ??
-  null;
+import { Card } from "primereact/card";
+import type {
+  needs,
+  PublicUserProfile,
+  skills,
+} from "../../types/UserProfile.types";
 
 const getKnowledgeName = (item: skills | needs): string | null =>
   item.knowledgeName?.trim() || null;
@@ -39,26 +37,24 @@ const KnowledgeBadges = ({
   );
 };
 
-export function DashboardProfileCard({ user }: { user: ApiUser }) {
+export function DashboardProfileCard({ user }: { user: PublicUserProfile }) {
   const fullName = `${user.firstName} ${user.lastName}`.trim();
   const location = [user.city, user.country].filter(Boolean).join(", ");
-  const profileImage = getProfileImage(user);
 
   return (
-    <article className="flex h-full flex-col rounded-2xl border border-primary-border/10 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+    <Card
+      className="h-full shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+      pt={{
+        root: { className: "rounded-2xl border border-primary-border/10" },
+        body: { className: "flex flex-1 flex-col p-5" },
+        content: { className: "flex flex-1 flex-col gap-5 p-0" },
+      }}
+    >
       <div className="flex items-center gap-4">
-        {profileImage ? (
-          <img
-            src={profileImage}
-            alt={`Photo de profil de ${fullName}`}
-            className="h-20 w-20 rounded-full border-4 border-primary-border/20 object-cover"
-          />
-        ) : (
-          <div
-            aria-label={`Photo de profil non renseignée pour ${fullName}`}
-            className="h-20 w-20 rounded-full border-4 border-dashed border-primary-border/20 bg-page-bg"
-          />
-        )}
+        <div
+          aria-label={`Photo de profil non renseignée pour ${fullName}`}
+          className="h-20 w-20 rounded-full border-4 border-dashed border-primary-border/20 bg-page-bg"
+        />
         <div>
           <h2 className="text-xl font-bold text-text">{fullName}</h2>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -67,27 +63,28 @@ export function DashboardProfileCard({ user }: { user: ApiUser }) {
         </div>
       </div>
 
-      <div className="mt-6 flex flex-1 flex-col gap-5">
-        <section>
-          <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
-            Compétences
-          </h3>
-          <KnowledgeBadges
-            items={user.skills ?? []}
-            emptyLabel="Aucune compétence renseignée"
-          />
-        </section>
+      <section>
+        <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
+          Compétences
+        </h3>
+        <KnowledgeBadges
+          items={user.skills ?? []}
+          emptyLabel="Aucune compétence renseignée"
+        />
+      </section>
 
-        <section>
-          <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
-            Besoins
-          </h3>
-          <KnowledgeBadges
-            items={user.needs ?? []}
-            emptyLabel="Aucun besoin renseigné"
-          />
-        </section>
-      </div>
-    </article>
+      <section>
+        <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.08em] text-text">
+          Besoins
+        </h3>
+        <KnowledgeBadges
+          items={user.needs ?? []}
+          emptyLabel="Aucun besoin renseigné"
+        />
+      </section>
+    </Card>
   );
 }
+
+
+

--- a/app_front-end/src/services/userService.ts
+++ b/app_front-end/src/services/userService.ts
@@ -2,6 +2,7 @@ import { API_USERS_URL } from '../constantes';
 import {
   ApiUser,
   type needs,
+  type PublicUserProfile,
   type RawKnowledgeItem,
   type skills,
   type UpdateProfilUserPayload,
@@ -23,7 +24,16 @@ const normalizeUser = (user: ApiUser): ApiUser => ({
   project: user.project ?? null,
 });
 
-export const getAllUsers = async (): Promise<ApiUser[]> => {
+const normalizePublicUser = (user: PublicUserProfile): PublicUserProfile => ({
+  firstName: user.firstName,
+  lastName: user.lastName,
+  city: user.city,
+  country: user.country,
+  skills: (user.skills ?? []).map(normalizeKnowledgeItem),
+  needs: (user.needs ?? []).map(normalizeKnowledgeItem),
+});
+
+export const getAllUsers = async (): Promise<PublicUserProfile[]> => {
   const response = await fetch(`${API_USERS_URL}`, {
     credentials: "include",
   });
@@ -32,8 +42,8 @@ export const getAllUsers = async (): Promise<ApiUser[]> => {
     throw new Error(`Erreur HTTP: ${response.status}`);
   }
 
-  const data: ApiUser[] = await response.json();
-  return data.map(normalizeUser);
+  const data: PublicUserProfile[] = await response.json();
+  return data.map(normalizePublicUser);
 };
 
 

--- a/app_front-end/src/styles/prime-overrides.css
+++ b/app_front-end/src/styles/prime-overrides.css
@@ -346,7 +346,8 @@
   border-radius: var(--ts-radius);
 }
 
-.profile-field-label {
+.profile-field-label,
+.auth-field-label {
   display: block;
   font-family: var(--ts-font-body);
   font-size: var(--ts-text-sm);

--- a/app_front-end/src/types/UserProfile.types.ts
+++ b/app_front-end/src/types/UserProfile.types.ts
@@ -35,6 +35,16 @@ export type ProfileSectionData =
   | ProjectItem[]
   | null;
 
+/** Public listing payload from GET /users (UserPublicResponseDTO). */
+export interface PublicUserProfile {
+  firstName: string;
+  lastName: string;
+  city: string;
+  country: string;
+  skills: skills[];
+  needs: needs[];
+}
+
 export interface ApiUser {
   id?: number;
   firstName: string;

--- a/app_front-end/src/types/auth.types.ts
+++ b/app_front-end/src/types/auth.types.ts
@@ -53,6 +53,8 @@ export type FranceCityAutocompleteProps = {
   onChange: (city: string) => void;
   onBlur?: () => void;
   disabled?: boolean;
+  id?: string;
+  "aria-labelledby"?: string;
 };
 
 export type AuthMessageVariant = "error" | "success";


### PR DESCRIPTION
GET /users only returns public profile fields, but the dashboard still typed and normalized the full ApiUser shape, including photo fields that never arrive. Introduce PublicUserProfile, wire getAllUsers and the dashboard card to it, and render members with PrimeReact Card plus the padding the pass-through had stripped.
Auth forms relied on placeholders alone, so the accessibility tree flagged every input as unlabeled. Add visible htmlFor/id labels on login, register and password reset, expose id/aria-labelledby on the city autocomplete, and set French aria-labels on Password toggleMask icons. Footer copyright contrast is restored to solid white.