### PR TITLE
refactor: rename dashboard to catalog

### DIFF
--- a/app_front-end/src/components/catalog/CatalogProfileCard.tsx
+++ b/app_front-end/src/components/catalog/CatalogProfileCard.tsx
@@ -37,7 +37,7 @@ const KnowledgeBadges = ({
   );
 };
 
-export function DashboardProfileCard({ user }: { user: PublicUserProfile }) {
+export function CatalogProfileCard({ user }: { user: PublicUserProfile }) {
   const fullName = `${user.firstName} ${user.lastName}`.trim();
   const location = [user.city, user.country].filter(Boolean).join(", ");
 
@@ -85,6 +85,3 @@ export function DashboardProfileCard({ user }: { user: PublicUserProfile }) {
     </Card>
   );
 }
-
-
-

--- a/app_front-end/src/components/commons/Header.tsx
+++ b/app_front-end/src/components/commons/Header.tsx
@@ -17,9 +17,9 @@ export const Header: FC = () => {
     logoutUser();
   };
 
-  const goToDashboard = () => {
+  const goToCatalog = () => {
     setMenuOpen(false);
-    navigate({ to: "/dashboard" });
+    navigate({ to: "/catalog" });
   };
 
   const goToProfile = () => {
@@ -67,8 +67,8 @@ export const Header: FC = () => {
         <ul className="m-0 flex list-none items-center gap-10 p-0 max-md:w-full max-md:flex-col max-md:gap-3 md:gap-8 lg:gap-10">
           {!isAuthPage && (
             <li className="w-full md:w-auto">
-              <button type="button" className={navLinkClassName} onClick={goToDashboard}>
-                Tableau de bord
+              <button type="button" className={navLinkClassName} onClick={goToCatalog}>
+                Catalogue
               </button>
             </li>
           )}

--- a/app_front-end/src/pages/CatalogPage.tsx
+++ b/app_front-end/src/pages/CatalogPage.tsx
@@ -2,17 +2,17 @@ import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { Header } from "../components/commons/Header";
 import { Footer } from "../components/commons/Footer";
-import { DashboardProfileCard } from "../components/dashboard/DashboardProfileCard";
+import { CatalogProfileCard } from "../components/catalog/CatalogProfileCard";
 import { useAuth } from "../context/AuthContext";
 import { useUsersQuery } from "../hooks/useUserQuery";
 
-const DashboardState = ({ message }: { message: string }) => (
+const CatalogState = ({ message }: { message: string }) => (
   <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-primary-border/10 bg-white p-8 text-center shadow-sm">
     <p className="text-base font-semibold text-text">{message}</p>
   </div>
 );
 
-export function DashboardPage() {
+export function CatalogPage() {
   const { user, isLoading: authLoading, isError: authError } = useAuth();
   const navigate = useNavigate();
   const isAuthenticated = Boolean(user);
@@ -32,12 +32,12 @@ export function DashboardPage() {
 
   const renderContent = () => {
     if (authLoading || usersLoading) {
-      return <DashboardState message="Chargement des profils..." />;
+      return <CatalogState message="Chargement des profils..." />;
     }
 
     if (usersError) {
       return (
-        <DashboardState
+        <CatalogState
           message={
             error instanceof Error
               ? error.message
@@ -48,13 +48,13 @@ export function DashboardPage() {
     }
 
     if (users.length === 0) {
-      return <DashboardState message="Aucun profil disponible pour le moment." />;
+      return <CatalogState message="Aucun profil disponible pour le moment." />;
     }
 
     return (
       <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
         {users.map((member, index) => (
-          <DashboardProfileCard
+          <CatalogProfileCard
             key={`${member.firstName}-${member.lastName}-${index}`}
             user={member}
           />
@@ -74,7 +74,7 @@ export function DashboardPage() {
       <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:py-12">
         <header className="max-w-3xl">
           <p className="mb-2 text-sm font-bold uppercase tracking-[0.16em] text-primary-border">
-            Dashboard
+            Catalogue
           </p>
           <h1 className="text-3xl font-bold text-text">
             Découvrez les membres de TrocSkillHub

--- a/app_front-end/src/routeTree.ts
+++ b/app_front-end/src/routeTree.ts
@@ -1,5 +1,5 @@
 import { rootRoute } from "./routes/__root";
-import { dashboardRoute } from "./routes/dashboard";
+import { catalogRoute } from "./routes/catalog";
 import { indexRoute } from "./routes/index";
 import { loginRoute } from "./routes/login";
 import { profileRoute } from "./routes/profile";
@@ -7,6 +7,6 @@ import { profileRoute } from "./routes/profile";
 export const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
-  dashboardRoute,
+  catalogRoute,
   profileRoute,
 ]);

--- a/app_front-end/src/routes/catalog.tsx
+++ b/app_front-end/src/routes/catalog.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from "@tanstack/react-router";
+import { CatalogPage } from "../pages/CatalogPage";
+import { rootRoute } from "./__root";
+
+export const catalogRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/catalog",
+  component: CatalogPage,
+});

--- a/app_front-end/src/routes/dashboard.tsx
+++ b/app_front-end/src/routes/dashboard.tsx
@@ -1,9 +1,0 @@
-import { createRoute } from "@tanstack/react-router";
-import { DashboardPage } from "../pages/DashboardPage";
-import { rootRoute } from "./__root";
-
-export const dashboardRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/dashboard",
-  component: DashboardPage,
-});

--- a/app_front-end/src/testing/Header.test.tsx
+++ b/app_front-end/src/testing/Header.test.tsx
@@ -69,13 +69,13 @@ describe("Header", () => {
 
   it("hides the navigation links on the login page", async () => {
     renderHeader("/login");
-    await expect.element(page.getByText("Tableau de bord")).not.toBeInTheDocument();
+    await expect.element(page.getByText("Catalogue")).not.toBeInTheDocument();
     await expect.element(page.getByText("Mon Profil")).not.toBeInTheDocument();
   });
 
   it("shows the navigation links on other pages", async () => {
     renderHeader("/profile");
-    await expect.element(page.getByText("Tableau de bord")).toBeInTheDocument();
+    await expect.element(page.getByText("Catalogue")).toBeInTheDocument();
     await expect.element(page.getByText("Mon Profil")).toBeInTheDocument();
   });
 });

--- a/app_front-end/src/testing/testRouter.tsx
+++ b/app_front-end/src/testing/testRouter.tsx
@@ -34,7 +34,7 @@ export function createComponentTestRouter(
     }),
     createRoute({
       getParentRoute: () => rootRoute,
-      path: "/dashboard",
+      path: "/catalog",
       component: Component,
     }),
   ]);


### PR DESCRIPTION
The members listing is a catalogue of public profiles, not an admin dashboard. Rename the route to /catalog, the page and card components, and the nav label to Catalogue so the URL, code and UI use the same term.